### PR TITLE
Fix UnicodeDecodeError on Windows DOS Command

### DIFF
--- a/thefuck/output_readers/rerun.py
+++ b/thefuck/output_readers/rerun.py
@@ -59,7 +59,7 @@ def get_output(script, expanded):
         result = Popen(expanded, shell=True, stdin=PIPE,
                        stdout=PIPE, stderr=STDOUT, env=env)
         if _wait_output(result, is_slow):
-            output = result.stdout.read().decode('utf-8')
+            output = str(result.stdout.read()).encode('utf-8').decode(sys.stdout.encoding)
             logs.debug(u'Received output: {}'.format(output))
             return output
         else:


### PR DESCRIPTION
When I run thefuck on Windows 10 with a command in Spanish, I got this error message: 

_"UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 23: invalid continuation byte"._

This patch could be a fix to this error.